### PR TITLE
Update constraints for the xibs

### DIFF
--- a/WhatsNew/Resources/WhatsNew.xib
+++ b/WhatsNew/Resources/WhatsNew.xib
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="13196" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="13529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13173"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13527"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>

--- a/WhatsNew/Resources/WhatsNew.xib
+++ b/WhatsNew/Resources/WhatsNew.xib
@@ -35,8 +35,8 @@
                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="DFT-ZF-fEm">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="90"/>
                                             <subviews>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="What's New" textAlignment="right" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="fKN-eO-Tbq">
-                                                    <rect key="frame" x="104.5" y="25" width="167.5" height="40"/>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="What's New" textAlignment="center" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="fKN-eO-Tbq">
+                                                    <rect key="frame" x="30" y="25" width="315" height="40"/>
                                                     <fontDescription key="fontDescription" type="boldSystem" pointSize="30"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
@@ -44,9 +44,9 @@
                                             </subviews>
                                             <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                                             <constraints>
-                                                <constraint firstItem="fKN-eO-Tbq" firstAttribute="centerX" secondItem="DFT-ZF-fEm" secondAttribute="centerX" id="PXc-ND-jAu"/>
+                                                <constraint firstAttribute="trailing" secondItem="fKN-eO-Tbq" secondAttribute="trailing" constant="30" id="5is-kf-V6a"/>
+                                                <constraint firstItem="fKN-eO-Tbq" firstAttribute="leading" secondItem="DFT-ZF-fEm" secondAttribute="leading" constant="30" id="NTR-VO-vUO"/>
                                                 <constraint firstItem="fKN-eO-Tbq" firstAttribute="top" secondItem="DFT-ZF-fEm" secondAttribute="top" constant="25" id="VGS-on-KWg"/>
-                                                <constraint firstItem="fKN-eO-Tbq" firstAttribute="centerY" secondItem="DFT-ZF-fEm" secondAttribute="centerY" id="d9T-Z5-bNt"/>
                                                 <constraint firstAttribute="bottom" secondItem="fKN-eO-Tbq" secondAttribute="bottom" constant="25" id="dXX-9c-Pkx"/>
                                             </constraints>
                                         </view>

--- a/WhatsNew/Resources/WhatsNew.xib
+++ b/WhatsNew/Resources/WhatsNew.xib
@@ -24,7 +24,7 @@
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
                 <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="q0I-iV-mNw">
-                    <rect key="frame" x="0.0" y="20" width="375" height="560"/>
+                    <rect key="frame" x="0.0" y="20" width="375" height="558"/>
                     <subviews>
                         <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="dhQ-Nl-Wc2">
                             <rect key="frame" x="0.0" y="0.0" width="375" height="90"/>
@@ -58,47 +58,35 @@
                         <constraint firstItem="dhQ-Nl-Wc2" firstAttribute="width" secondItem="q0I-iV-mNw" secondAttribute="width" id="mVJ-OS-MJY"/>
                     </constraints>
                 </scrollView>
-                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="wON-2C-CFX">
-                    <rect key="frame" x="0.0" y="577" width="375" height="50"/>
-                    <subviews>
-                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="sAB-F2-Y7K">
-                            <rect key="frame" x="30" y="2.5" width="315" height="45"/>
-                            <color key="backgroundColor" white="0.0" alpha="1" colorSpace="calibratedWhite"/>
-                            <constraints>
-                                <constraint firstAttribute="height" constant="45" id="mOy-4M-bMK"/>
-                            </constraints>
-                            <fontDescription key="fontDescription" name="SFUIDisplay-Bold" family="SF UI Display" pointSize="18"/>
-                            <state key="normal" title="Continue">
-                                <color key="titleColor" red="0.94509803920000002" green="0.92941176469999998" blue="0.039215686270000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                            </state>
-                            <userDefinedRuntimeAttributes>
-                                <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
-                                    <integer key="value" value="8"/>
-                                </userDefinedRuntimeAttribute>
-                            </userDefinedRuntimeAttributes>
-                            <connections>
-                                <action selector="continue" destination="-1" eventType="touchUpInside" id="Jck-a8-q0C"/>
-                            </connections>
-                        </button>
-                    </subviews>
-                    <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
+                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="sAB-F2-Y7K">
+                    <rect key="frame" x="30" y="580" width="315" height="45"/>
+                    <color key="backgroundColor" white="0.0" alpha="1" colorSpace="calibratedWhite"/>
                     <constraints>
-                        <constraint firstAttribute="height" constant="50" id="AMG-FJ-maW"/>
-                        <constraint firstItem="sAB-F2-Y7K" firstAttribute="leading" secondItem="wON-2C-CFX" secondAttribute="leading" constant="30" id="ER8-aR-ROL"/>
-                        <constraint firstItem="sAB-F2-Y7K" firstAttribute="centerY" secondItem="wON-2C-CFX" secondAttribute="centerY" id="sTb-Ga-Uuc"/>
-                        <constraint firstAttribute="trailing" secondItem="sAB-F2-Y7K" secondAttribute="trailing" constant="30" id="xM0-nR-Vhv"/>
+                        <constraint firstAttribute="height" constant="45" id="mOy-4M-bMK"/>
                     </constraints>
-                </view>
+                    <fontDescription key="fontDescription" name="SFUIDisplay-Bold" family="SF UI Display" pointSize="18"/>
+                    <state key="normal" title="Continue">
+                        <color key="titleColor" red="0.94509803920000002" green="0.92941176469999998" blue="0.039215686270000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                    </state>
+                    <userDefinedRuntimeAttributes>
+                        <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
+                            <integer key="value" value="8"/>
+                        </userDefinedRuntimeAttribute>
+                    </userDefinedRuntimeAttributes>
+                    <connections>
+                        <action selector="continue" destination="-1" eventType="touchUpInside" id="Jck-a8-q0C"/>
+                    </connections>
+                </button>
             </subviews>
             <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
             <constraints>
-                <constraint firstItem="wON-2C-CFX" firstAttribute="top" secondItem="q0I-iV-mNw" secondAttribute="bottom" constant="-3" id="5DN-Xy-DJC"/>
+                <constraint firstItem="sAB-F2-Y7K" firstAttribute="leading" secondItem="vUN-kp-3ea" secondAttribute="leading" constant="30" id="1zg-9d-ZBx"/>
                 <constraint firstItem="q0I-iV-mNw" firstAttribute="leading" secondItem="vUN-kp-3ea" secondAttribute="leading" id="FqS-eV-cfG"/>
+                <constraint firstItem="vUN-kp-3ea" firstAttribute="bottom" secondItem="sAB-F2-Y7K" secondAttribute="bottom" constant="42" id="HJ2-xV-PwZ"/>
+                <constraint firstItem="sAB-F2-Y7K" firstAttribute="top" secondItem="q0I-iV-mNw" secondAttribute="bottom" constant="2" id="KnH-3p-EAT"/>
                 <constraint firstItem="vUN-kp-3ea" firstAttribute="trailing" secondItem="q0I-iV-mNw" secondAttribute="trailing" id="Pjk-3B-DXJ"/>
-                <constraint firstItem="wON-2C-CFX" firstAttribute="leading" secondItem="vUN-kp-3ea" secondAttribute="leading" id="RGG-vd-75u"/>
-                <constraint firstItem="vUN-kp-3ea" firstAttribute="bottom" secondItem="wON-2C-CFX" secondAttribute="bottom" constant="40" id="jgD-LK-a0Z"/>
+                <constraint firstItem="vUN-kp-3ea" firstAttribute="trailing" secondItem="sAB-F2-Y7K" secondAttribute="trailing" constant="30" id="i0N-1x-n2R"/>
                 <constraint firstItem="q0I-iV-mNw" firstAttribute="top" secondItem="vUN-kp-3ea" secondAttribute="top" id="kaZ-K2-UW3"/>
-                <constraint firstItem="wON-2C-CFX" firstAttribute="trailing" secondItem="vUN-kp-3ea" secondAttribute="trailing" id="rhx-Sm-qS0"/>
             </constraints>
             <viewLayoutGuide key="safeArea" id="vUN-kp-3ea"/>
             <point key="canvasLocation" x="34.5" y="53.5"/>

--- a/WhatsNew/Resources/WhatsNew.xib
+++ b/WhatsNew/Resources/WhatsNew.xib
@@ -68,6 +68,7 @@
                         <constraint firstItem="dhQ-Nl-Wc2" firstAttribute="leading" secondItem="q0I-iV-mNw" secondAttribute="leading" id="hc2-bF-8vF"/>
                         <constraint firstAttribute="bottom" secondItem="dhQ-Nl-Wc2" secondAttribute="bottom" constant="10" id="kz6-MH-Hgx"/>
                         <constraint firstItem="dhQ-Nl-Wc2" firstAttribute="top" secondItem="q0I-iV-mNw" secondAttribute="top" id="l68-CR-wR8"/>
+                        <constraint firstItem="dhQ-Nl-Wc2" firstAttribute="width" secondItem="q0I-iV-mNw" secondAttribute="width" id="mVJ-OS-MJY"/>
                     </constraints>
                 </scrollView>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="wON-2C-CFX">
@@ -104,7 +105,6 @@
             </subviews>
             <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
             <constraints>
-                <constraint firstItem="dhQ-Nl-Wc2" firstAttribute="width" secondItem="iN0-l3-epB" secondAttribute="width" id="3kn-60-URO"/>
                 <constraint firstItem="wON-2C-CFX" firstAttribute="top" secondItem="q0I-iV-mNw" secondAttribute="bottom" constant="-3" id="5DN-Xy-DJC"/>
                 <constraint firstItem="q0I-iV-mNw" firstAttribute="leading" secondItem="vUN-kp-3ea" secondAttribute="leading" id="FqS-eV-cfG"/>
                 <constraint firstItem="vUN-kp-3ea" firstAttribute="trailing" secondItem="q0I-iV-mNw" secondAttribute="trailing" id="Pjk-3B-DXJ"/>

--- a/WhatsNew/Resources/WhatsNew.xib
+++ b/WhatsNew/Resources/WhatsNew.xib
@@ -106,7 +106,7 @@
             <constraints>
                 <constraint firstItem="dhQ-Nl-Wc2" firstAttribute="width" secondItem="iN0-l3-epB" secondAttribute="width" id="3kn-60-URO"/>
                 <constraint firstItem="wON-2C-CFX" firstAttribute="top" secondItem="q0I-iV-mNw" secondAttribute="bottom" constant="-3" id="5DN-Xy-DJC"/>
-                <constraint firstItem="q0I-iV-mNw" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" id="FqS-eV-cfG"/>
+                <constraint firstItem="q0I-iV-mNw" firstAttribute="leading" secondItem="vUN-kp-3ea" secondAttribute="leading" id="FqS-eV-cfG"/>
                 <constraint firstItem="vUN-kp-3ea" firstAttribute="trailing" secondItem="q0I-iV-mNw" secondAttribute="trailing" id="Pjk-3B-DXJ"/>
                 <constraint firstItem="wON-2C-CFX" firstAttribute="leading" secondItem="vUN-kp-3ea" secondAttribute="leading" id="RGG-vd-75u"/>
                 <constraint firstItem="vUN-kp-3ea" firstAttribute="bottom" secondItem="wON-2C-CFX" secondAttribute="bottom" constant="40" id="jgD-LK-a0Z"/>

--- a/WhatsNew/Resources/WhatsNew.xib
+++ b/WhatsNew/Resources/WhatsNew.xib
@@ -29,35 +29,22 @@
                         <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="dhQ-Nl-Wc2">
                             <rect key="frame" x="0.0" y="0.0" width="375" height="90"/>
                             <subviews>
-                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="05P-IR-imh">
+                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="DFT-ZF-fEm">
                                     <rect key="frame" x="0.0" y="0.0" width="375" height="90"/>
                                     <subviews>
-                                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="DFT-ZF-fEm">
-                                            <rect key="frame" x="0.0" y="0.0" width="375" height="90"/>
-                                            <subviews>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="What's New" textAlignment="center" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="fKN-eO-Tbq">
-                                                    <rect key="frame" x="30" y="25" width="315" height="40"/>
-                                                    <fontDescription key="fontDescription" type="boldSystem" pointSize="30"/>
-                                                    <nil key="textColor"/>
-                                                    <nil key="highlightedColor"/>
-                                                </label>
-                                            </subviews>
-                                            <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
-                                            <constraints>
-                                                <constraint firstAttribute="trailing" secondItem="fKN-eO-Tbq" secondAttribute="trailing" constant="30" id="5is-kf-V6a"/>
-                                                <constraint firstItem="fKN-eO-Tbq" firstAttribute="leading" secondItem="DFT-ZF-fEm" secondAttribute="leading" constant="30" id="NTR-VO-vUO"/>
-                                                <constraint firstItem="fKN-eO-Tbq" firstAttribute="top" secondItem="DFT-ZF-fEm" secondAttribute="top" constant="25" id="VGS-on-KWg"/>
-                                                <constraint firstAttribute="bottom" secondItem="fKN-eO-Tbq" secondAttribute="bottom" constant="25" id="dXX-9c-Pkx"/>
-                                            </constraints>
-                                        </view>
+                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="What's New" textAlignment="center" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="fKN-eO-Tbq">
+                                            <rect key="frame" x="30" y="25" width="315" height="40"/>
+                                            <fontDescription key="fontDescription" type="boldSystem" pointSize="30"/>
+                                            <nil key="textColor"/>
+                                            <nil key="highlightedColor"/>
+                                        </label>
                                     </subviews>
+                                    <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                                     <constraints>
-                                        <constraint firstItem="DFT-ZF-fEm" firstAttribute="centerY" secondItem="05P-IR-imh" secondAttribute="centerY" id="0hY-8G-AgS"/>
-                                        <constraint firstItem="DFT-ZF-fEm" firstAttribute="leading" secondItem="05P-IR-imh" secondAttribute="leading" id="K4R-Xj-RmO"/>
-                                        <constraint firstAttribute="trailing" secondItem="DFT-ZF-fEm" secondAttribute="trailing" id="TZf-6U-76J"/>
-                                        <constraint firstItem="DFT-ZF-fEm" firstAttribute="top" secondItem="05P-IR-imh" secondAttribute="top" id="jBS-xN-frl"/>
-                                        <constraint firstItem="DFT-ZF-fEm" firstAttribute="centerX" secondItem="05P-IR-imh" secondAttribute="centerX" id="taW-uj-DO8"/>
-                                        <constraint firstAttribute="bottom" secondItem="DFT-ZF-fEm" secondAttribute="bottom" id="v3q-gY-OKe"/>
+                                        <constraint firstAttribute="trailing" secondItem="fKN-eO-Tbq" secondAttribute="trailing" constant="30" id="5is-kf-V6a"/>
+                                        <constraint firstItem="fKN-eO-Tbq" firstAttribute="leading" secondItem="DFT-ZF-fEm" secondAttribute="leading" constant="30" id="NTR-VO-vUO"/>
+                                        <constraint firstItem="fKN-eO-Tbq" firstAttribute="top" secondItem="DFT-ZF-fEm" secondAttribute="top" constant="25" id="VGS-on-KWg"/>
+                                        <constraint firstAttribute="bottom" secondItem="fKN-eO-Tbq" secondAttribute="bottom" constant="25" id="dXX-9c-Pkx"/>
                                     </constraints>
                                 </view>
                             </subviews>

--- a/WhatsNew/Resources/WhatsNewItemImageView.xib
+++ b/WhatsNew/Resources/WhatsNewItemImageView.xib
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="13196" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="13529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13173"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13527"/>
         <capability name="Aspect ratio constraints" minToolsVersion="5.1"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>

--- a/WhatsNew/Resources/WhatsNewItemImageView.xib
+++ b/WhatsNew/Resources/WhatsNewItemImageView.xib
@@ -30,13 +30,13 @@
                         <constraint firstAttribute="width" secondItem="YUp-od-Q3r" secondAttribute="height" multiplier="1:1" id="HFl-ee-01d"/>
                     </constraints>
                 </imageView>
-                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Feature Title" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="DHq-c8-hDU">
+                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Feature Title" textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="DHq-c8-hDU">
                     <rect key="frame" x="100" y="10" width="245" height="50"/>
                     <fontDescription key="fontDescription" type="system" weight="medium" pointSize="26"/>
                     <nil key="textColor"/>
                     <nil key="highlightedColor"/>
                 </label>
-                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Automatically use your preferred font size specified in the Settings app." textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="9Mz-s6-ygM">
+                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Automatically use your preferred font size specified in the Settings app." textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="9Mz-s6-ygM">
                     <rect key="frame" x="30" y="70" width="315" height="59"/>
                     <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                     <nil key="textColor"/>
@@ -46,14 +46,15 @@
             <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
             <constraints>
                 <constraint firstItem="9Mz-s6-ygM" firstAttribute="leading" secondItem="vUN-kp-3ea" secondAttribute="leading" constant="30" id="3Um-qK-suN"/>
-                <constraint firstItem="DHq-c8-hDU" firstAttribute="centerY" secondItem="YUp-od-Q3r" secondAttribute="centerY" id="53d-2a-qBf"/>
-                <constraint firstItem="9Mz-s6-ygM" firstAttribute="top" secondItem="YUp-od-Q3r" secondAttribute="bottom" constant="10" id="Eun-DV-JoX"/>
+                <constraint firstItem="DHq-c8-hDU" firstAttribute="top" secondItem="YUp-od-Q3r" secondAttribute="top" id="91A-Gf-wNf"/>
                 <constraint firstItem="vUN-kp-3ea" firstAttribute="trailing" secondItem="DHq-c8-hDU" secondAttribute="trailing" constant="30" id="Hnl-TZ-yyR"/>
                 <constraint firstItem="YUp-od-Q3r" firstAttribute="top" secondItem="vUN-kp-3ea" secondAttribute="top" constant="10" id="IOa-c3-Qfk"/>
+                <constraint firstItem="9Mz-s6-ygM" firstAttribute="top" secondItem="DHq-c8-hDU" secondAttribute="bottom" constant="10" id="Ito-zx-pxG"/>
                 <constraint firstItem="vUN-kp-3ea" firstAttribute="trailing" secondItem="9Mz-s6-ygM" secondAttribute="trailing" constant="30" id="WOy-Wd-fAF"/>
                 <constraint firstItem="DHq-c8-hDU" firstAttribute="top" secondItem="vUN-kp-3ea" secondAttribute="top" constant="10" id="YLG-HO-eQw"/>
                 <constraint firstItem="DHq-c8-hDU" firstAttribute="leading" secondItem="YUp-od-Q3r" secondAttribute="trailing" constant="20" id="apE-HS-8dR"/>
                 <constraint firstItem="vUN-kp-3ea" firstAttribute="bottom" secondItem="9Mz-s6-ygM" secondAttribute="bottom" constant="10" id="kJN-Zk-hme"/>
+                <constraint firstItem="DHq-c8-hDU" firstAttribute="bottom" secondItem="YUp-od-Q3r" secondAttribute="bottom" priority="500" id="oFn-Uc-auh"/>
                 <constraint firstItem="YUp-od-Q3r" firstAttribute="leading" secondItem="vUN-kp-3ea" secondAttribute="leading" constant="30" id="xl6-a9-Ulb"/>
             </constraints>
             <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>

--- a/WhatsNew/Resources/WhatsNewItemTextView.xib
+++ b/WhatsNew/Resources/WhatsNewItemTextView.xib
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="13196" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="13529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13173"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13527"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>

--- a/WhatsNew/Resources/WhatsNewItemTextView.xib
+++ b/WhatsNew/Resources/WhatsNewItemTextView.xib
@@ -21,13 +21,13 @@
             <rect key="frame" x="0.0" y="0.0" width="375" height="123"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
-                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" text="Automatically use your preferred font size specified in the Settings app." textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="bE0-3G-XlW">
+                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" text="Automatically use your preferred font size specified in the Settings app." textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="bE0-3G-XlW">
                     <rect key="frame" x="30" y="51.5" width="315" height="61.5"/>
                     <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                     <nil key="textColor"/>
                     <nil key="highlightedColor"/>
                 </label>
-                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Dynamic Font Size" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="AnA-4W-WKK">
+                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Dynamic Font Size" textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="AnA-4W-WKK">
                     <rect key="frame" x="30" y="10" width="315" height="32"/>
                     <fontDescription key="fontDescription" type="system" weight="medium" pointSize="26"/>
                     <nil key="textColor"/>

--- a/WhatsNew/Resources/WhatsNewItemTextView.xib
+++ b/WhatsNew/Resources/WhatsNewItemTextView.xib
@@ -36,13 +36,13 @@
             </subviews>
             <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
             <constraints>
-                <constraint firstAttribute="trailing" secondItem="bE0-3G-XlW" secondAttribute="trailing" constant="30" id="AHh-1E-b4G"/>
                 <constraint firstItem="bE0-3G-XlW" firstAttribute="top" secondItem="AnA-4W-WKK" secondAttribute="bottom" constant="10" id="B8C-TY-JvW"/>
                 <constraint firstItem="AnA-4W-WKK" firstAttribute="leading" secondItem="vUN-kp-3ea" secondAttribute="leading" constant="30" id="E1D-KK-VbY"/>
                 <constraint firstItem="vUN-kp-3ea" firstAttribute="trailing" secondItem="AnA-4W-WKK" secondAttribute="trailing" constant="30" id="Jdt-Sz-9UD"/>
                 <constraint firstItem="vUN-kp-3ea" firstAttribute="bottom" secondItem="bE0-3G-XlW" secondAttribute="bottom" constant="10" id="MUx-lY-QPm"/>
                 <constraint firstItem="bE0-3G-XlW" firstAttribute="leading" secondItem="vUN-kp-3ea" secondAttribute="leading" constant="30" id="W2h-93-fkU"/>
                 <constraint firstItem="AnA-4W-WKK" firstAttribute="top" secondItem="vUN-kp-3ea" secondAttribute="top" constant="10" id="oKL-Lf-lIe"/>
+                <constraint firstItem="vUN-kp-3ea" firstAttribute="trailing" secondItem="bE0-3G-XlW" secondAttribute="trailing" constant="30" id="uDP-RC-apF"/>
             </constraints>
             <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
             <viewLayoutGuide key="safeArea" id="vUN-kp-3ea"/>


### PR DESCRIPTION
Hi, I've updated some of the constraints inside the various xibs:

1. In WhatsNew xib I've set the stack view to track the scroll view width and not the main view one to fix the landscape mode and I've set leading and trailing constraints to the main title to allow it to wrap on multiple lines. I've also removed an unnecessary view inside the the stack view for the main title.
2. In WhatsNewItemTextView xib I've update the only constraint that still track the superview directly and not the safe area
3. In WhatsNewItemImageView xib I've updated the title constrains to allow it to wrap on multiple lines and not be truncated at the first one

I've also a question, I've seen that the continue button is inside a subview that is not much of utility and that has a negative top distance to the scroll view. There is a reason for that or is some kind of drag error?
