### PR TITLE
Rename didShow to markCurrentVersionAsPresented

### DIFF
--- a/WhatsNew/Items/WhatsNew.swift
+++ b/WhatsNew/Items/WhatsNew.swift
@@ -7,16 +7,16 @@
 
 import Foundation
 
-struct WhatsNew {
-    static let bundle = Bundle(for: WhatsNewViewController.self)
-    static let appVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String
-    static let userDefaultsKey = "LatestAppVersionPresented"
+public struct WhatsNew {
+    internal static let bundle = Bundle(for: WhatsNewViewController.self)
+    internal static let appVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String
+    internal static let userDefaultsKey = "LatestAppVersionPresented"
 
-    static func didShow() {
+    public static func markCurrentVersionAsPresented() {
         UserDefaults.standard.set(appVersion, forKey: userDefaultsKey)
     }
 
-    static func shouldPresent(with option: PresentationOption) -> Bool {
+    internal static func shouldPresent(with option: PresentationOption) -> Bool {
         let previousAppVersion = UserDefaults.standard.string(forKey: userDefaultsKey)
         let didUpdate = previousAppVersion != appVersion
         // If main bundle was not updated, never present.

--- a/WhatsNew/Items/WhatsNew.swift
+++ b/WhatsNew/Items/WhatsNew.swift
@@ -7,16 +7,16 @@
 
 import Foundation
 
-public struct WhatsNew {
-    internal static let bundle = Bundle(for: WhatsNewViewController.self)
-    internal static let appVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String
-    internal static let userDefaultsKey = "LatestAppVersionPresented"
+struct WhatsNew {
+    static let bundle = Bundle(for: WhatsNewViewController.self)
+    static let appVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String
+    static let userDefaultsKey = "LatestAppVersionPresented"
 
-    public static func markCurrentVersionAsPresented() {
+    static func markCurrentVersionAsPresented() {
         UserDefaults.standard.set(appVersion, forKey: userDefaultsKey)
     }
 
-    internal static func shouldPresent(with option: PresentationOption) -> Bool {
+    static func shouldPresent(with option: PresentationOption) -> Bool {
         let previousAppVersion = UserDefaults.standard.string(forKey: userDefaultsKey)
         let didUpdate = previousAppVersion != appVersion
         // If main bundle was not updated, never present.
@@ -25,7 +25,9 @@ public struct WhatsNew {
         switch option {
         case .always: return true
         case .majorVersion: return didChangeMajorVersion(previous: previousAppVersion, current: appVersion)
-        case .never: return false
+        case .never:
+            markCurrentVersionAsPresented()
+            return false
         }
     }
 

--- a/WhatsNew/WhatsNewViewController.swift
+++ b/WhatsNew/WhatsNewViewController.swift
@@ -96,7 +96,7 @@ public class WhatsNewViewController: UIViewController {
     }
 
     @IBAction func `continue`() {
-        WhatsNew.didShow()
+        WhatsNew.markCurrentVersionAsPresented()
         dismiss(animated: true, completion: onDismissal)
     }
 }


### PR DESCRIPTION
Rename `didShow` to `markCurrentVersionAsPresented` and expose it. Motivation behind this is there may be cases where it does not make sense to show "What's New" to a user and to have WhatsNew manage it.