### PR TITLE
Rename presentation options

### DIFF
--- a/Example/Tests/WhatsNewTests.swift
+++ b/Example/Tests/WhatsNewTests.swift
@@ -17,37 +17,59 @@ class WhatsNewTests: XCTestCase {
         UserDefaults.standard.removePersistentDomain(forName: Bundle.main.bundleIdentifier!)
     }
     
+    func testShouldNotPresent_WhenCurrentVersionIsUndefined() {
+        XCTAssertFalse(WhatsNew.shouldPresent(with: .always, currentVersion: nil))
+    }
+    
+    
+    
+    
+    
     func testShouldPresentAlways_WhenFirstVersionInstalled() {
-        XCTAssertTrue(WhatsNew.shouldPresent(with: .always))
+        XCTAssertTrue(WhatsNew.shouldPresent(with: .always, currentVersion: "1.0"))
     }
 
     func testShouldPresentAlways_WhenUpdatingVersion() {
-        UserDefaults.standard.set("0.9", forKey: WhatsNew.userDefaultsKey)
-        XCTAssertTrue(WhatsNew.shouldPresent(with: .always))
+        UserDefaults.standard.set("1.0", forKey: WhatsNew.userDefaultsKeyLatestAppVersionPresented)
+        XCTAssertTrue(WhatsNew.shouldPresent(with: .always, currentVersion: "1.1"))
+        XCTAssertTrue(WhatsNew.shouldPresent(with: .always, currentVersion: "1.0.1"))
     }
 
-    func testShouldNotPresentAlways_WhenNotUpdatingVersion() {
-        UserDefaults.standard.set("1.0", forKey: WhatsNew.userDefaultsKey)
-        XCTAssertFalse(WhatsNew.shouldPresent(with: .always))
+    func testShouldNotPresent_WhenNotUpdatingVersion() {
+        UserDefaults.standard.set("1.0", forKey: WhatsNew.userDefaultsKeyLatestAppVersionPresented)
+        XCTAssertFalse(WhatsNew.shouldPresent(with: .always, currentVersion: "1.0"))
+        XCTAssertFalse(WhatsNew.shouldPresent(with: .always, currentVersion: "1.0.0"))
+        XCTAssertFalse(WhatsNew.shouldPresent(with: .always, currentVersion: "1"))
     }
 
+    
+    
+    
     func testShouldPresentMajorVersion_WhenUpdatingVersionMajor() {
-        UserDefaults.standard.set("0.9", forKey: WhatsNew.userDefaultsKey)
-        XCTAssertTrue(WhatsNew.shouldPresent(with: .majorVersion))
+        UserDefaults.standard.set("1.9", forKey: WhatsNew.userDefaultsKeyLatestAppVersionPresented)
+        XCTAssertTrue(WhatsNew.shouldPresent(with: .majorVersion, currentVersion: "2.0"))
+        XCTAssertTrue(WhatsNew.shouldPresent(with: .majorVersion, currentVersion: "2.0.0"))
     }
 
     func testShouldNotPresentMajorVersion_WhenUpdatingVersionMinor() {
-        UserDefaults.standard.set("1.0.1", forKey: WhatsNew.userDefaultsKey)
-        XCTAssertFalse(WhatsNew.shouldPresent(with: .majorVersion))
-    }
-
-    func testShouldNotPresentNever_WhenUpdatingVersion() {
-        UserDefaults.standard.set("0.9", forKey: WhatsNew.userDefaultsKey)
-        XCTAssertFalse(WhatsNew.shouldPresent(with: .never))
+        UserDefaults.standard.set("1.0", forKey: WhatsNew.userDefaultsKeyLatestAppVersionPresented)
+        XCTAssertFalse(WhatsNew.shouldPresent(with: .majorVersion, currentVersion: "1.1"))
+        XCTAssertFalse(WhatsNew.shouldPresent(with: .majorVersion, currentVersion: "1.0.1"))
+        XCTAssertFalse(WhatsNew.shouldPresent(with: .majorVersion, currentVersion: "2.1"))
     }
     
+    
+    
+
+    func testShouldNotPresentNever_WhenUpdatingVersion() {
+        UserDefaults.standard.set("1.0", forKey: WhatsNew.userDefaultsKeyLatestAppVersionPresented)
+        XCTAssertFalse(WhatsNew.shouldPresent(with: .never, currentVersion: "1.0"))
+        XCTAssertFalse(WhatsNew.shouldPresent(with: .never, currentVersion: nil))
+        XCTAssertFalse(WhatsNew.shouldPresent(with: .never, currentVersion: "2.0"))
+    }
+    
+    
     func testShouldPresent_WhenDebugPresentationOption() {
-        UserDefaults.standard.set("1.0", forKey: WhatsNew.userDefaultsKey)
-        XCTAssertTrue(WhatsNew.shouldPresent(with: .debug))
+        XCTAssertTrue(WhatsNew.shouldPresent(with: .debug, currentVersion: "2.4"))
     }
 }

--- a/Example/Tests/WhatsNewTests.swift
+++ b/Example/Tests/WhatsNewTests.swift
@@ -18,7 +18,7 @@ class WhatsNewTests: XCTestCase {
     }
     
     func testShouldNotPresent_WhenCurrentVersionIsUndefined() {
-        XCTAssertFalse(WhatsNew.shouldPresent(with: .always, currentVersion: nil))
+        XCTAssertFalse(WhatsNew.shouldPresent(with: .onUpdate, currentVersion: nil))
     }
     
     
@@ -26,13 +26,13 @@ class WhatsNewTests: XCTestCase {
     
     
     func testShouldPresentAlways_WhenFirstVersionInstalled() {
-        XCTAssertTrue(WhatsNew.shouldPresent(with: .always, currentVersion: "1.0"))
+        XCTAssertTrue(WhatsNew.shouldPresent(with: .onUpdate, currentVersion: "1.0"))
     }
 
     func testShouldPresentAlways_WhenUpdatingVersion() {
         UserDefaults.standard.set("1.0", forKey: WhatsNew.userDefaultsKeyLatestAppVersionPresented)
-        XCTAssertTrue(WhatsNew.shouldPresent(with: .always, currentVersion: "1.1"))
-        XCTAssertTrue(WhatsNew.shouldPresent(with: .always, currentVersion: "1.0.1"))
+        XCTAssertTrue(WhatsNew.shouldPresent(with: .onUpdate, currentVersion: "1.1"))
+        XCTAssertTrue(WhatsNew.shouldPresent(with: .onUpdate, currentVersion: "1.0.1"))
     }
 
 
@@ -40,15 +40,15 @@ class WhatsNewTests: XCTestCase {
     
     func testShouldPresentMajorVersion_WhenUpdatingVersionMajor() {
         UserDefaults.standard.set("1.9", forKey: WhatsNew.userDefaultsKeyLatestAppVersionPresented)
-        XCTAssertTrue(WhatsNew.shouldPresent(with: .majorVersion, currentVersion: "2.0"))
-        XCTAssertTrue(WhatsNew.shouldPresent(with: .majorVersion, currentVersion: "2.0.0"))
+        XCTAssertTrue(WhatsNew.shouldPresent(with: .onMajorUpdate, currentVersion: "2.0"))
+        XCTAssertTrue(WhatsNew.shouldPresent(with: .onMajorUpdate, currentVersion: "2.0.0"))
     }
 
     func testShouldNotPresentMajorVersion_WhenUpdatingVersionMinor() {
         UserDefaults.standard.set("1.0", forKey: WhatsNew.userDefaultsKeyLatestAppVersionPresented)
-        XCTAssertFalse(WhatsNew.shouldPresent(with: .majorVersion, currentVersion: "1.1"))
-        XCTAssertFalse(WhatsNew.shouldPresent(with: .majorVersion, currentVersion: "1.0.1"))
-        XCTAssertFalse(WhatsNew.shouldPresent(with: .majorVersion, currentVersion: "2.1"))
+        XCTAssertFalse(WhatsNew.shouldPresent(with: .onMajorUpdate, currentVersion: "1.1"))
+        XCTAssertFalse(WhatsNew.shouldPresent(with: .onMajorUpdate, currentVersion: "1.0.1"))
+        XCTAssertFalse(WhatsNew.shouldPresent(with: .onMajorUpdate, currentVersion: "2.1"))
     }
     
     

--- a/Example/Tests/WhatsNewTests.swift
+++ b/Example/Tests/WhatsNewTests.swift
@@ -35,14 +35,7 @@ class WhatsNewTests: XCTestCase {
         XCTAssertTrue(WhatsNew.shouldPresent(with: .always, currentVersion: "1.0.1"))
     }
 
-    func testShouldNotPresent_WhenNotUpdatingVersion() {
-        UserDefaults.standard.set("1.0", forKey: WhatsNew.userDefaultsKeyLatestAppVersionPresented)
-        XCTAssertFalse(WhatsNew.shouldPresent(with: .always, currentVersion: "1.0"))
-        XCTAssertFalse(WhatsNew.shouldPresent(with: .always, currentVersion: "1.0.0"))
-        XCTAssertFalse(WhatsNew.shouldPresent(with: .always, currentVersion: "1"))
-    }
 
-    
     
     
     func testShouldPresentMajorVersion_WhenUpdatingVersionMajor() {

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ There are a bunch of customizable properties with relative documentation.
 
 ```swift
 /// Defines when to present the What's New view controller. Check the `PresentationOption` enum for more details.
-public var presentationOption: PresentationOption = .always
+public var presentationOption: PresentationOption = .onUpdate
 
 /// Closure invoked when the user dismisses the view controller.
 public var onDismissal: (() -> Void)?

--- a/WhatsNew/Items/PresentationOption.swift
+++ b/WhatsNew/Items/PresentationOption.swift
@@ -10,9 +10,9 @@ import Foundation
 /// Defines when the "What's New" view controller is presented.
 public enum PresentationOption {
     /// present if the main bundle version changes.
-    case always
+    case onUpdate
     /// Only present if the main bundle changes major version.
-    case majorVersion
+    case onMajorUpdate
     /// Never present.
     case never
     /// present always

--- a/WhatsNew/Items/WhatsNew.swift
+++ b/WhatsNew/Items/WhatsNew.swift
@@ -14,7 +14,6 @@ public struct WhatsNew {
 
     static func markCurrentVersionAsPresented() {
         UserDefaults.standard.set(appVersion, forKey: userDefaultsKey)
-        UserDefaults.standard.synchronize()
     }
 
     public static func shouldPresent(with option: PresentationOption = .always) -> Bool {

--- a/WhatsNew/Items/WhatsNew.swift
+++ b/WhatsNew/Items/WhatsNew.swift
@@ -9,15 +9,15 @@ import Foundation
 
 public struct WhatsNew {
     static let bundle = Bundle(for: WhatsNewViewController.self)
-    static let appVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String
+    public static let appVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String
     static let userDefaultsKey = "LatestAppVersionPresented"
 
     static func markCurrentVersionAsPresented() {
         UserDefaults.standard.set(appVersion, forKey: userDefaultsKey)
     }
 
-    public static func shouldPresent(with option: PresentationOption = .always) -> Bool {
-        guard let currentAppVersion = appVersion else { return false }
+    public static func shouldPresent(with option: PresentationOption = .always, currentVersion: String? = appVersion) -> Bool {
+        guard let currentAppVersion = currentVersion else { return false }
         let previousAppVersion = UserDefaults.standard.string(forKey: userDefaultsKey)
         let didUpdate = previousAppVersion != appVersion
         

--- a/WhatsNew/Items/WhatsNew.swift
+++ b/WhatsNew/Items/WhatsNew.swift
@@ -18,22 +18,30 @@ public struct WhatsNew {
     }
 
     public static func shouldPresent(with option: PresentationOption = .always) -> Bool {
+        guard let currentAppVersion = appVersion else { return false }
         let previousAppVersion = UserDefaults.standard.string(forKey: userDefaultsKey)
-        
         let didUpdate = previousAppVersion != appVersion
         
-        // Choose based on the selected presentation option.
         switch option {
         case .debug: return true
         case .never: return false
-        case .majorVersion: return didChangeMajorVersion(previous: previousAppVersion, current: appVersion)
+        case .majorVersion: return didUpdate && isMajorVersion(version: currentAppVersion)
         case .always: return didUpdate
         }
     }
-
-    private static func didChangeMajorVersion(previous: String?, current: String?) -> Bool {
-        guard let previousMajor = previous?.split(separator: ".").first, let previousMajorInt = Int(previousMajor) else { return false }
-        guard let currentMajor = current?.split(separator: ".").first, let currentMajorInt = Int(currentMajor) else { return false }
-        return currentMajorInt > previousMajorInt
+    
+    private static func isMajorVersion(version: String) -> Bool {
+        let components = version.split(separator: ".")
+        // ensure minor version or hotfix version is either nil or 0
+        
+        guard components.count > 1 else { return true }
+        let minorUpdate = components[1]
+        guard minorUpdate == "0" else { return false }
+        
+        guard components.count > 2 else { return true }
+        let hotfixUpdate = components[2]
+        guard hotfixUpdate == "0" else { return false }
+        
+        return true
     }
 }

--- a/WhatsNew/Items/WhatsNew.swift
+++ b/WhatsNew/Items/WhatsNew.swift
@@ -16,7 +16,7 @@ public struct WhatsNew {
         UserDefaults.standard.set(appVersion, forKey: userDefaultsKeyLatestAppVersionPresented)
     }
 
-    public static func shouldPresent(with option: PresentationOption = .always, currentVersion: String? = appVersion) -> Bool {
+    public static func shouldPresent(with option: PresentationOption = .onUpdate, currentVersion: String? = appVersion) -> Bool {
         guard let currentAppVersion = currentVersion else { return false }
         let previousAppVersion = UserDefaults.standard.string(forKey: userDefaultsKeyLatestAppVersionPresented)
         let didUpdate = previousAppVersion != currentAppVersion
@@ -24,8 +24,8 @@ public struct WhatsNew {
         switch option {
         case .debug: return true
         case .never: return false
-        case .majorVersion: return didUpdate && isMajorVersion(version: currentAppVersion)
-        case .always: return didUpdate
+        case .onMajorUpdate: return didUpdate && isMajorVersion(version: currentAppVersion)
+        case .onUpdate: return didUpdate
         }
     }
     

--- a/WhatsNew/Items/WhatsNew.swift
+++ b/WhatsNew/Items/WhatsNew.swift
@@ -10,15 +10,15 @@ import Foundation
 public struct WhatsNew {
     static let bundle = Bundle(for: WhatsNewViewController.self)
     public static let appVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String
-    static let userDefaultsKey = "LatestAppVersionPresented"
+    static let userDefaultsKeyLatestAppVersionPresented = "LatestAppVersionPresented"
 
     static func markCurrentVersionAsPresented() {
-        UserDefaults.standard.set(appVersion, forKey: userDefaultsKey)
+        UserDefaults.standard.set(appVersion, forKey: userDefaultsKeyLatestAppVersionPresented)
     }
 
     public static func shouldPresent(with option: PresentationOption = .always, currentVersion: String? = appVersion) -> Bool {
         guard let currentAppVersion = currentVersion else { return false }
-        let previousAppVersion = UserDefaults.standard.string(forKey: userDefaultsKey)
+        let previousAppVersion = UserDefaults.standard.string(forKey: userDefaultsKeyLatestAppVersionPresented)
         let didUpdate = previousAppVersion != appVersion
         
         switch option {

--- a/WhatsNew/Items/WhatsNew.swift
+++ b/WhatsNew/Items/WhatsNew.swift
@@ -19,7 +19,7 @@ public struct WhatsNew {
     public static func shouldPresent(with option: PresentationOption = .always, currentVersion: String? = appVersion) -> Bool {
         guard let currentAppVersion = currentVersion else { return false }
         let previousAppVersion = UserDefaults.standard.string(forKey: userDefaultsKeyLatestAppVersionPresented)
-        let didUpdate = previousAppVersion != appVersion
+        let didUpdate = previousAppVersion != currentAppVersion
         
         switch option {
         case .debug: return true

--- a/WhatsNew/WhatsNewViewController.swift
+++ b/WhatsNew/WhatsNewViewController.swift
@@ -12,7 +12,7 @@ import UIKit
 public class WhatsNewViewController: UIViewController {
 
     /// Defines when to present the What's New view controller. Check the `PresentationOption` enum for more details.
-    public var presentationOption: PresentationOption = .always
+    public var presentationOption: PresentationOption = .onUpdate
     /// Closure invoked when the user dismisses the view controller.
     public var onDismissal: (() -> Void)?
     /// Text of the top title.


### PR DESCRIPTION
In my eyes the presentation option `.always` is not named very well because it suggests that the view is presented *always*. However it is only presented on every version update. This is why I suggest renaming. This does make the library more intuitive for new developers.