### PR TITLE
Add ability to set item image tint color.

### DIFF
--- a/WhatsNew.podspec
+++ b/WhatsNew.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'WhatsNew'
-  s.version          = '0.4.4'
+  s.version          = '0.4.5'
   s.summary          = 'Showcase new features after an app update similar to Pages, Numbers and Keynote.'
 
 # This description is used to generate tags and improve search results.

--- a/WhatsNew/WhatsNewViewController.swift
+++ b/WhatsNew/WhatsNewViewController.swift
@@ -33,6 +33,12 @@ public class WhatsNewViewController: UIViewController {
             titleLabel?.font = titleFont
         }
     }
+    /// Tint color of the feature item image, if one exists.
+    public var itemImageTintColor: UIColor? = nil {
+        didSet {
+            setUp(with: items)
+        }
+    }
     /// Title color of the feature items.
     public var itemTitleColor: UIColor = .black {
         didSet {
@@ -139,6 +145,9 @@ public class WhatsNewViewController: UIViewController {
             switch item {
             case .image(let title, let subtitle, let image):
                 let itemView = WhatsNewItemImageView.loadFromNib()
+                if let imageTintColor = itemImageTintColor {
+                    itemView.imageView.tintColor = imageTintColor
+                }
                 itemView.set(image: image, title: title, subtitle: subtitle, titleColor: itemTitleColor, subtitleColor: itemSubtitleColor, titleFont: itemTitleFont, subtitleFont: itemSubtitleFont)
                 view = itemView
             case .text(let title, let subtitle):


### PR DESCRIPTION
• Allows for changing item image tint color (for use with template images) via itemImageTintColor property on WhatsNewViewController instance.

Example usage:

`
let whatsNew = WhatsNewViewController(items: [ . . . ])
whatsNew.itemImageTintColor = .red
whatsNew.presentIfNeeded(on: self)
`